### PR TITLE
[Quant][Prototype] Expand FP8 manual fusion: AR + more models

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/quant_fusion.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_fusion.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass
 
 import torch
 
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8StaticTensorSym,
@@ -27,6 +31,9 @@ def rms_norm_input_quant(
     residual: torch.Tensor | None,
     linear: torch.nn.Module,
 ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
+    if residual is not None and get_tensor_model_parallel_world_size() > 1:
+        x = tensor_model_parallel_all_reduce(x)
+
     quant_key = getattr(linear, "input_quant_key", None)
     if quant_key is None:
         if residual is None:

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -179,6 +179,7 @@ class LlamaAttention(nn.Module):
             output_size=hidden_size,
             bias=bias_o_proj,
             quant_config=quant_config,
+            reduce_results=False,
             prefix=f"{prefix}.o_proj",
         )
 
@@ -310,6 +311,7 @@ class LlamaDecoderLayer(nn.Module):
             quant_config=quant_config,
             bias=getattr(config, "mlp_bias", False),
             prefix=f"{prefix}.mlp",
+            reduce_results=False,
         )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -88,6 +88,7 @@ class Qwen2MLP(nn.Module):
         hidden_act: str,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        reduce_results: bool = True,
     ) -> None:
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -102,6 +103,7 @@ class Qwen2MLP(nn.Module):
             hidden_size,
             bias=False,
             quant_config=quant_config,
+            reduce_results=reduce_results,
             prefix=f"{prefix}.down_proj",
         )
         if hidden_act != "silu":

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -42,6 +42,9 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_fusion import (
+    rms_norm_input_quant,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.sequence import IntermediateTensors
@@ -109,6 +112,7 @@ class Qwen3Attention(nn.Module):
             hidden_size,
             bias=False,
             quant_config=quant_config,
+            reduce_results=False,
             prefix=f"{prefix}.o_proj",
         )
 
@@ -207,6 +211,7 @@ class Qwen3DecoderLayer(nn.Module):
             hidden_act=config.hidden_act,
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",
+            reduce_results=False,
         )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(
@@ -219,19 +224,23 @@ class Qwen3DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # Self Attention
-        if residual is None:
-            residual = hidden_states
-            hidden_states = self.input_layernorm(hidden_states)
-        else:
-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states, residual = rms_norm_input_quant(
+            self.input_layernorm,
+            hidden_states,
+            residual,
+            self.self_attn.qkv_proj,
+        )
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
         )
 
-        # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states, residual = rms_norm_input_quant(
+            self.post_attention_layernorm,
+            hidden_states,
+            residual,
+            self.mlp.gate_up_proj,
+        )
         hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
 


### PR DESCRIPTION
Builds on #42469 — extends the manual-fusion model-code pattern to:

- AllReduce + RMSNorm + FP8 quant (TP>1).
- Qwen3 (same static-per-tensor coverage as Llama).

Targets \`mgoin:nvfp4-input-quant-prototype\` so the diff is just the delta over the previous PR. Will retarget \`vllm-project/vllm:main\` once #42469 lands.

## What's new

\`quant_fusion.py\`: when \`residual is not None\` and \`tp_size>1\`, the helper unconditionally calls \`tensor_model_parallel_all_reduce(x)\` before the existing add+rms_norm+quant path. Single helper covers both AR and non-AR cases because \`residual is None\` is the only call site (layer 0's first norm) where the input doesn't come from a TP-sharded matmul.

\`llama.py\` / \`qwen3.py\` (+ \`qwen2.py\` for the MLP base): \`o_proj\` and \`down_proj\` constructed with \`reduce_results=False\`, decoder \`forward\` already calls the helper. At tp=1 this is a no-op (RowParallelLinear already skipped AR).

## Caveats

- Chain version only (AR + fused norm+quant as two kernel launches). FlashInfer's \`flashinfer_trtllm_fused_allreduce_norm\` would collapse both into one launch but requires workspace setup — left as a follow-up.
- Only static-per-tensor FP8 is wired through the QuantKey dispatch in this PR; dynamic/block/silu_and_mul variants are separate follow-ups.

## Test plan

- [x] Llama-3.2-1B-FP8 tp=1 eager + compile — output unchanged.
- [x] Llama-3.2-1B-FP8 tp=2 eager + compile — coherent generation, AR exercised.
- [ ] Same on a Qwen3 FP8 checkpoint.

AI-assisted.